### PR TITLE
fix: remove duplicate gh actions runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,10 @@
 name: Docs
 
-on: [push, workflow_dispatch]
+on:
+  pull_request:
+    types: [opened, reopened]
+  push:
+    branches: [main]
 
 jobs:
   markdown-lint:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,11 @@
 name: Docs
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, closed]
+  push:
+    branches-ignore: [main]
 
 jobs:
   markdown-lint:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, edited, reopened]
   push:
     branches: [main]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, synchronize, reopened]
   push:
     branches: [main]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,6 @@
 name: Docs
 
-on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, closed]
-  push:
-    branches-ignore: [main]
+on: [push, workflow_dispatch]
 
 jobs:
   markdown-lint:

--- a/.github/workflows/terraformlint.yml
+++ b/.github/workflows/terraformlint.yml
@@ -1,6 +1,10 @@
 name: Terraform Lint
 
-on: [push, workflow_dispatch]
+on:
+  pull_request:
+    types: [opened, reopened]
+  push:
+    branches: [main]
 
 jobs:
   tflint:

--- a/.github/workflows/terraformlint.yml
+++ b/.github/workflows/terraformlint.yml
@@ -2,7 +2,7 @@ name: Terraform Lint
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, edited, reopened]
   push:
     branches: [main]
 

--- a/.github/workflows/terraformlint.yml
+++ b/.github/workflows/terraformlint.yml
@@ -1,39 +1,33 @@
 name: Terraform Lint
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, closed]
+  push:
+    branches-ignore: [main]
 
 jobs:
   tflint:
     runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
         os: [ubuntu-latest]
-
     steps:
       - uses: actions/checkout@v2
         name: Checkout source code
-
       - uses: actions/cache@v2
         name: Cache plugin dir
         with:
           path: ~/.tflint.d/plugins
           key: ${{ matrix.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
-
       - uses: terraform-linters/setup-tflint@v1
         name: Setup TFLint
         with:
           tflint_version: v0.29.0
-
       - name: Show version
         run: tflint --version
-
       - name: Init TFLint
         run: tflint --init
-
       - name: Run TFLint
         run: tflint -f compact

--- a/.github/workflows/terraformlint.yml
+++ b/.github/workflows/terraformlint.yml
@@ -2,7 +2,7 @@ name: Terraform Lint
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, synchronize, reopened]
   push:
     branches: [main]
 

--- a/.github/workflows/terraformlint.yml
+++ b/.github/workflows/terraformlint.yml
@@ -1,18 +1,10 @@
 name: Terraform Lint
 
-on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, closed]
-  push:
-    branches-ignore: [main]
+on: [push, workflow_dispatch]
 
 jobs:
   tflint:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         name: Checkout source code


### PR DESCRIPTION
With the previous 'on' triggers github actions has duplicate runs. This update removes the duplicates.